### PR TITLE
generalisation and gui handling

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,12 +29,13 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine and only allow access
   # via 127.0.0.1 to disable public access
   # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
-  config.vm.network "forwarded_port", guest: 6443, host: 6443, host_ip: "127.0.0.1"
-  config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 6443, host: 6443, host_ip: "127.0.0.1", id: "kubernetes-api"
+  config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1", id: "kubernetes-2"
+  config.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1", id: "react"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.110.3"
+  config.vm.network "private_network", ip: "192.168.110.2"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -52,11 +53,13 @@ Vagrant.configure("2") do |config|
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb|
-    vb.name="l4w_dev"
      # Display the VirtualBox GUI when booting the machine
      vb.gui = false
+     vb.customize ["modifyvm", :id, "--vram", "128"]
+     vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+     vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
      # Customize the amount of memory on the VM:
-     vb.memory = "8192"
+     vb.memory = "16384"
      # Customize the amount of CPUs assigned
      vb.cpus = 6
   end


### PR DESCRIPTION
- Port forwardings are named
- Sets up 3d acceleration in VM to prevent firefox or other GUI apps to require too much CPU
- IP was switched to the "production" one (had .3 for dev)
- removed VM name, allowing multiple VMs to be started.